### PR TITLE
dev into main: introduce level2 VWAN (rabu-m365-sandbox)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -180,7 +180,7 @@ Providers in `root-common.hcl` are conditionally included based on deployment un
 2. **Provider version mismatch**: Check `root-common.hcl` for version constraints
 3. **Backend state issues**: Bootstrap helper creates backend storage; runs with local state initially
 4. **Missing parent management group**: `az-ecp-parent` must run before `az-alz-base`
-5. **Path extraction regex**: Unit path extracted via `regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0]`
+5. **Path extraction regex**: Unit path extracted via `regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0]`
 
 ---
 

--- a/deployments/managed/dark-contoso-lab/dev/env.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/env.hcl
@@ -14,10 +14,10 @@ locals {
   # IPv4 address from which ECP networks will be derived; normally the lowest IP a /16 address space
   ecp_network_main_ipv4_address_space = "10.110.0.0/16"
 
-  ecp_azure_devops_organization_name = "dark-contoso-lab"
-  ecp_azure_devops_project_name      = "ECP"
-  ecp_azure_devops_automation_repository_name   = "ECP.Automation"
-  ecp_azure_devops_configuration_repository_name   = "ECP.Configuration"
+  ecp_azure_devops_organization_name             = "dark-contoso-lab"
+  ecp_azure_devops_project_name                  = "ECP"
+  ecp_azure_devops_automation_repository_name    = "ECP.Automation"
+  ecp_azure_devops_configuration_repository_name = "ECP.Configuration"
 
   env_azure_tags = {
     # "hidden-ecpTgUnitEnv" = format("%s/env.hcl", get_parent_terragrunt_dir())

--- a/deployments/managed/dark-contoso-lab/dev/level0/automation/ado-repo-sync-automation/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level0/automation/ado-repo-sync-automation/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/dark-contoso-lab/dev/level0/automation/ado-repo-sync-configuration/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level0/automation/ado-repo-sync-configuration/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/dark-contoso-lab/dev/level0/bootstrap/az-launchpad-bootstrap-helper/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level0/bootstrap/az-launchpad-bootstrap-helper/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/dark-contoso-lab/dev/level0/finalizer/az-launchpad-bootstrap-finalizer/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level0/finalizer/az-launchpad-bootstrap-finalizer/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/dark-contoso-lab/dev/level0/launchpad/ado-mpool/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level0/launchpad/ado-mpool/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/dark-contoso-lab/dev/level0/launchpad/ado-project/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level0/launchpad/ado-project/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/dark-contoso-lab/dev/level0/launchpad/az-devcenter/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level0/launchpad/az-devcenter/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/dark-contoso-lab/dev/level0/launchpad/az-launchpad-backend/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level0/launchpad/az-launchpad-backend/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/dark-contoso-lab/dev/level0/launchpad/az-launchpad-main/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level0/launchpad/az-launchpad-main/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/dark-contoso-lab/dev/level0/launchpad/az-launchpad-network/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level0/launchpad/az-launchpad-network/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/dark-contoso-lab/dev/level1/ecproot/az-ecp-parent/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level1/ecproot/az-ecp-parent/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }
@@ -47,7 +47,7 @@ inputs = {
   ecp_deployment_entraid_contributor_group_member_principal_ids = [
     "7d341c29-3220-4f0c-b154-b08bde0ee92e" # A-Admin
   ]
-  ecp_deployment_entraid_reader_group_member_principal_ids      = [
+  ecp_deployment_entraid_reader_group_member_principal_ids = [
     "05b1d8bc-7b58-4695-9a5e-98029da27119" # C-Admin
   ]
 }

--- a/deployments/managed/dark-contoso-lab/dev/level1/ecproot/az-platform-subscriptions/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level1/ecproot/az-platform-subscriptions/terragrunt.hcl
@@ -29,8 +29,8 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
-  
+  path = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
+
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/dark-contoso-lab/dev/level1/entraid/entraid-policies/terragrunt.hcl.disabled
+++ b/deployments/managed/dark-contoso-lab/dev/level1/entraid/entraid-policies/terragrunt.hcl.disabled
@@ -24,7 +24,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path   = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path   = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose = false
 }
 

--- a/deployments/managed/dark-contoso-lab/dev/level1/management/az-alz-base/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level1/management/az-alz-base/terragrunt.hcl
@@ -29,8 +29,8 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
-  
+  path = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
+
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/dark-contoso-lab/dev/level1/management/az-alz-management-resources/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level1/management/az-alz-management-resources/terragrunt.hcl
@@ -29,8 +29,8 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
-  
+  path = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
+
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/dark-contoso-lab/dev/level1/management/az-alz-shared-library-render/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level1/management/az-alz-shared-library-render/terragrunt.hcl
@@ -29,8 +29,8 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
-  
+  path = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
+
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/dark-contoso-lab/dev/level1/management/az-privatelink-privatedns-zones/terragrunt.hcl
+++ b/deployments/managed/dark-contoso-lab/dev/level1/management/az-privatelink-privatedns-zones/terragrunt.hcl
@@ -29,8 +29,8 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
-  
+  path = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
+
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/env.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/env.hcl
@@ -12,10 +12,10 @@ locals {
 
   ecp_network_main_ipv4_address_space = "10.224.0.0/16" # IPv4 address from which ECP networks will be derived; normally the lowest IP a /16 address space
 
-  ecp_azure_devops_organization_name = "rabuzu-m365"
-  ecp_azure_devops_project_name      = "ECP"
-  ecp_azure_devops_automation_repository_name   = "ECP.Automation"
-  ecp_azure_devops_configuration_repository_name   = "ECP.Configuration"
+  ecp_azure_devops_organization_name             = "rabuzu-m365"
+  ecp_azure_devops_project_name                  = "ECP"
+  ecp_azure_devops_automation_repository_name    = "ECP.Automation"
+  ecp_azure_devops_configuration_repository_name = "ECP.Configuration"
 
   env_azure_tags = {
     # "hidden-ecpTgUnitEnv" = format("%s/env.hcl", get_parent_terragrunt_dir())

--- a/deployments/managed/rabu-m365-sandbox/dev/level0/automation/ado-pipeline/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level0/automation/ado-pipeline/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level0/automation/ado-repo-sync-automation/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level0/automation/ado-repo-sync-automation/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level0/automation/ado-repo-sync-configuration/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level0/automation/ado-repo-sync-configuration/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level0/bootstrap/az-launchpad-bootstrap-helper/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level0/bootstrap/az-launchpad-bootstrap-helper/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level0/finalizer/az-launchpad-bootstrap-finalizer/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level0/finalizer/az-launchpad-bootstrap-finalizer/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level0/launchpad/ado-mpool/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level0/launchpad/ado-mpool/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level0/launchpad/ado-project/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level0/launchpad/ado-project/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level0/launchpad/az-devcenter/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level0/launchpad/az-devcenter/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level0/launchpad/az-launchpad-backend/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level0/launchpad/az-launchpad-backend/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level0/launchpad/az-launchpad-main/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level0/launchpad/az-launchpad-main/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level0/launchpad/az-launchpad-network/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level0/launchpad/az-launchpad-network/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level1/ecproot/az-ecp-parent/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level1/ecproot/az-ecp-parent/terragrunt.hcl
@@ -29,7 +29,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose         = false
   merge_strategy = "deep"
 }
@@ -45,9 +45,9 @@ inputs = {
   ecp_deployment_entraid_contributor_group_member_principal_ids = [
     "111d8248-5407-4cc2-8482-67f182b8cd78" # Adele Vance / AdeleV@m365.rabuzu.com
   ]
-  ecp_deployment_entraid_reader_group_member_principal_ids      = [
+  ecp_deployment_entraid_reader_group_member_principal_ids = [
     "111d8248-5407-4cc2-8482-67f182b8cd78", # Adele Vance / AdeleV@m365.rabuzu.com
-    "5c929fb8-b2eb-46de-99e3-c7a63127358a" # Alex Wilber / AlexW@m365.rabuzu.com
+    "5c929fb8-b2eb-46de-99e3-c7a63127358a"  # Alex Wilber / AlexW@m365.rabuzu.com
   ]
 
   # unit inputs mostly from unit-common.hcl

--- a/deployments/managed/rabu-m365-sandbox/dev/level1/ecproot/az-platform-subscriptions/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level1/ecproot/az-platform-subscriptions/terragrunt.hcl
@@ -29,8 +29,8 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
-  
+  path = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
+
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level1/entraid/entraid-policies/terragrunt.hcl.disabled
+++ b/deployments/managed/rabu-m365-sandbox/dev/level1/entraid/entraid-policies/terragrunt.hcl.disabled
@@ -24,7 +24,7 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path   = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
+  path   = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
   expose = false
 }
 

--- a/deployments/managed/rabu-m365-sandbox/dev/level1/management/az-alz-base/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level1/management/az-alz-base/terragrunt.hcl
@@ -29,8 +29,8 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
-  
+  path = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
+
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level1/management/az-alz-management-resources/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level1/management/az-alz-management-resources/terragrunt.hcl
@@ -29,8 +29,8 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
-  
+  path = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
+
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level1/management/az-alz-shared-library-render/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level1/management/az-alz-shared-library-render/terragrunt.hcl
@@ -29,8 +29,8 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
-  
+  path = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
+
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level1/management/az-privatelink-privatedns-zones/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level1/management/az-privatelink-privatedns-zones/terragrunt.hcl
@@ -29,8 +29,8 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*/(.+?/.+?/.+?)$", get_terragrunt_dir())[0][0])
-  
+  path = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
+
   expose         = false
   merge_strategy = "deep"
 }

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/area.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/area.hcl
@@ -1,0 +1,12 @@
+locals {
+  ecp_deployment_area = "ecpa"
+
+  area_azure_tags = {
+    # "hidden-ecpTgUnitArea" = format("%s/area.hcl", get_parent_terragrunt_dir())
+    workloadDescription = local.ecp_deployment_area
+  }
+}
+
+inputs = {
+  azure_tags = local.area_azure_tags
+}

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/README.md
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/README.md
@@ -1,0 +1,3 @@
+# Unit-specific ECP artefact library
+
+Folders here may contain additional ECP artefacts that will be considered when planning this unit. They are an addition to the shared ECP library and may also override or deactivate artefacts coming from the shared library.

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/virtualHubs/L2.Connectivity.default.virtualHub.disabled.json
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/virtualHubs/L2.Connectivity.default.virtualHub.disabled.json
@@ -1,0 +1,13 @@
+{
+    "artefactName": "l2-connectivity-westeurope-vwan-hub",
+    "nameElement": "",
+    
+    "location": "westeurope",
+
+    "addressPrefix": "10.1.0.0/23",
+    "hubRoutingPreference": "ExpressRoute",
+    "sku": "Basic",
+    "virtualRouterAutoScaleConfiguration": {
+        "minCapacity": 2
+    }
+}

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/virtualHubs/README.md
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/virtualHubs/README.md
@@ -1,0 +1,1 @@
+# Microsoft.Network/virtualHubs

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/virtualNetworks/README.md
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/virtualNetworks/README.md
@@ -1,0 +1,1 @@
+# Microsoft.Network/virtualNetworks

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/vpnConnections/L2.Connectivity.basic.vpnConnection.json
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/vpnConnections/L2.Connectivity.basic.vpnConnection.json
@@ -1,0 +1,50 @@
+{
+    "artefactName": "l2-connectivity-example-vpnConnection",
+
+    "location": "default",
+
+    "__vpnGateway": {
+        "id": "<ECP_ARTEFACT>:l2-connectivity-basic-example-vpnGateway"
+    },
+
+    "remoteVpnSite": {
+        "id": "<ECP_ARTEFACT>:l2-connectivity-example-staticrouting-vpnsite"
+    },
+    
+    "vpnLinkConnections": [
+        {
+            "properties": {
+                "connectionBandwidth": 10,
+                "ipsecPolicies": [
+                    {
+                        "saLifeTimeSeconds": 27000,
+                        "saDataSizeKilobytes": 102400000,
+                        "ipsecEncryption": "GCMAES256",
+                        "ipsecIntegrity": "GCMAES256",
+                        "ikeEncryption": "AES256",
+                        "ikeIntegrity": "SHA256",
+                        "dhGroup": "DHGroup24",
+                        "pfsGroup": "PFS24"
+                    }
+                ],
+                "vpnConnectionProtocolType": "IKEv2",
+                "enableBgp": false,
+                "enableRateLimiting": false,
+                "useLocalAzureIpAddress": false,
+                "usePolicyBasedTrafficSelectors": false,
+                "routingWeight": 0,
+                "dpdTimeoutSeconds": 0,
+                "vpnLinkConnectionMode": "Default",
+                "vpnGatewayCustomBgpAddresses": [],
+                
+                "preSharedKey": {
+                    "value": "",
+                    "valueRandom": true,
+                    "valueRandomVersion": 0,
+                    "valueKeyVaultRetrievable": true,
+                    "valueKeyVaultRead": false
+                }
+            }
+        }
+    ]
+}

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/vpnConnections/README.md
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/vpnConnections/README.md
@@ -1,0 +1,1 @@
+# Microsoft.Network/vpnGateways/vpnConnections

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/vpnGateways/L2.Connectivity.basic.vpnGateway.json
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/vpnGateways/L2.Connectivity.basic.vpnGateway.json
@@ -1,0 +1,9 @@
+{
+    "artefactName": "l2-connectivity-basic-example-vpnGateway",
+
+    "location": "default",
+
+    "virtualHub": {
+        "id": "<ECP_ARTEFACT>:l2-connectivity-default-vwan-hub"
+    }
+}

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/vpnGateways/README.md
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/vpnGateways/README.md
@@ -1,0 +1,1 @@
+# Microsoft.Network/vpnGateways

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/vpnSites/L2.Connectivity.example-bgpRouting.vpnSite.example.json
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/vpnSites/L2.Connectivity.example-bgpRouting.vpnSite.example.json
@@ -1,0 +1,43 @@
+{
+    "artefactName": "l2-connectivity-example-bgprouting-vpnsite",
+    "name": "ECP-Example-BGP-Routing",
+    "location": "default",
+    
+    "deviceProperties": {
+        "deviceModel": "ExampleModel (optional)",
+        "deviceVendor": "ExampleVendor (optional)"
+    },
+    "o365Policy": null,
+    "vpnSiteLinks": [
+        {
+            "name": "link1",
+            "properties": {
+                "bgpProperties": {
+                    "asn": 64512,
+                    "bgpPeeringAddress": "169.254.2.251"
+                },
+                "fqdn": null,
+                "ipAddress": "192.0.2.4",
+                "linkProperties": {
+                    "linkProviderName": "Provider Example",
+                    "linkSpeedInMbps": 256
+                }
+            }
+        },
+        {
+            "name": "link2",
+            "properties": {
+                "bgpProperties": {
+                    "asn": 64513,
+                    "bgpPeeringAddress": "169.254.2.252"
+                },
+                "fqdn": null,
+                "ipAddress": "192.0.2.5",
+                "linkProperties": {
+                    "linkProviderName": "Provider Example",
+                    "linkSpeedInMbps": 128
+                }
+            }
+        }
+    ]
+}

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/vpnSites/L2.Connectivity.example-staticRouting.vpnSite.json
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/vpnSites/L2.Connectivity.example-staticRouting.vpnSite.json
@@ -1,0 +1,33 @@
+{
+    "artefactName": "l2-connectivity-example-staticrouting-vpnsite",
+    "name": "ECP-Example-Static-Routing",
+    "location": "default",
+    "addressSpace": {
+        "addressPrefixes": [
+            "192.0.2.0/26",
+            "192.0.2.128/26"
+        ]
+    },
+    "deviceProperties": {
+        "deviceModel": "ExampleModel (optional)",
+        "deviceVendor": "ExampleVendor (optional)"
+    },
+    "o365Policy": null,
+    "vpnSiteLinks": [
+        {
+            "name": "link1",
+            "properties": {
+                "bgpProperties": {
+                    "asn": 64512,
+                    "bgpPeeringAddress": "169.254.2.251"
+                },
+                "fqdn": null,
+                "ipAddress": "192.0.2.2",
+                "linkProperties": {
+                    "linkProviderName": "Provider Example",
+                    "linkSpeedInMbps": 256
+                }
+            }
+        }
+    ]
+}

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/vpnSites/README.md
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/lib/vpnSites/README.md
@@ -1,0 +1,1 @@
+# Microsoft.Network/vpnSites

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-alz-connectivity-virtual-wan-main-location/terragrunt.hcl
@@ -1,0 +1,102 @@
+# includes merge "inputs", with last include taking precedence over previously defined.
+#     expose: allows content (e.g. locals) to be used by "include" 
+
+# root common (via git submodule)
+include "root-common" {
+  path           = format("%s/lib/terragrunt-common/ecp-v1/root-common.hcl", get_repo_root())
+  expose         = false
+  merge_strategy = "deep"
+}
+include "root" {
+  path           = find_in_parent_folders("root.hcl")
+  expose         = false
+  merge_strategy = "deep"
+}
+include "env" {
+  path           = find_in_parent_folders("env.hcl")
+  expose         = false
+  merge_strategy = "deep"
+}
+include "level" {
+  path           = find_in_parent_folders("level.hcl")
+  expose         = false
+  merge_strategy = "deep"
+}
+include "area" {
+  path           = find_in_parent_folders("area.hcl")
+  expose         = false
+  merge_strategy = "deep"
+}
+# unit common (via git submodule)
+include "unit-common" {
+  path = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
+
+  expose         = false
+  merge_strategy = "deep"
+}
+
+locals {
+  module_azure_tags = {
+    # "hidden-ecpTgUnit" = format("%s/terragrunt.hcl", get_terragrunt_dir())
+  }
+}
+
+inputs = {
+  # unit inputs mostly from unit-common.hcl
+  azure_tags = local.module_azure_tags
+
+  # Azure vWAN Settings that could be overridden
+  # virtual_wan_hubs = {
+  #   "ecpa-default-location" = {
+  #     # Basic (default) / Standard
+  #     sku = "Standard"
+  #   }
+  # }
+
+
+  ecp_archetype_definitions = {
+    name = "ecp-vwan"
+    virtual_wan = [
+      "l2-connectivity-vwan-basic-sku"
+    ]
+    virtual_hub = [
+      "l2-connectivity-default-vwan-hub"
+    ]
+    vpn_gateway = []
+    vpn_site = [
+      # "l2-connectivity-example-staticrouting-vpnsite"
+    ]
+    vpn_connection = [
+      # "l2-connectivity-example-vpnConnection"
+    ]
+    er_gateway    = []
+    er_connection = []
+  }
+
+  azure_location = "westeurope"
+  # ecp_network_main_ipv4_address_space = ""
+
+  ecp_hub_locations = {
+    # "ecpa-default-location" = {
+    #   azure_location = "westeurope"
+    #   ecp_network_main_ipv4_address_space = "10.1.0.0/16"
+    #   is_main_location = true
+    # }
+    "ireland" = {
+      azure_location                      = "northeurope"
+      ecp_network_main_ipv4_address_space = "10.2.0.0/16"
+      is_main_location                    = false
+    }
+    "frankfurt" = {
+      azure_location                      = "germanywestcentral"
+      ecp_network_main_ipv4_address_space = "10.3.0.0/16"
+      is_main_location                    = false
+    }
+    "gaevle" = {
+      azure_location                      = "swedencentral"
+      ecp_network_main_ipv4_address_space = "10.5.0.0/16"
+      is_main_location                    = false
+    }
+  }
+}
+

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-connectivity-management/terragrunt.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/connectivity/az-connectivity-management/terragrunt.hcl
@@ -29,7 +29,8 @@ include "area" {
 }
 # unit common (via git submodule)
 include "unit-common" {
-  path           = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
+  path = format("%s/lib/terragrunt-common/ecp-v1/%s/unit-common.hcl", get_repo_root(), regexall("^.*(?:\\\\|/)(.+?(?:\\\\|/).+?(?:\\\\|/).+?)$", get_terragrunt_dir())[0][0])
+
   expose         = false
   merge_strategy = "deep"
 }
@@ -37,13 +38,18 @@ include "unit-common" {
 locals {
   module_azure_tags = {
     # "hidden-ecpTgUnit" = format("%s/terragrunt.hcl", get_terragrunt_dir())
-
-    workloadBlockName = "ado"
   }
 }
 
 inputs = {
   # unit inputs mostly from unit-common.hcl
   azure_tags = local.module_azure_tags
-}
 
+  #  ecp_archetype_definitions = {
+  #     name = "ecp-con"
+  #     virtual_network = "l2-connectivity-vwan-basic-sku"
+  #     virtual_network_subnet = [
+  #       "l2-connectivity-default-vwan-hub"
+  #     ]
+  #   }
+}

--- a/deployments/managed/rabu-m365-sandbox/dev/level2/level.hcl
+++ b/deployments/managed/rabu-m365-sandbox/dev/level2/level.hcl
@@ -1,0 +1,11 @@
+locals {
+  ecp_deployment_level = "2"
+
+  level_azure_tags = {
+    # "hidden-ecpTgUnitLevel" = format("%s/level.hcl", get_parent_terragrunt_dir())
+  }
+}
+
+inputs = {
+  azure_tags = local.level_azure_tags
+}


### PR DESCRIPTION
Promotes accumulated `dev` changes into `main`, including new Level 2 vWAN connectivity for `rabu-m365-sandbox`, cross-cutting Windows-compatible regex, and housekeeping across both tenants.

## Changes

### Cross-cutting
- **Regex update** across all `terragrunt.hcl` files: path extraction regex updated for Windows path compatibility

### `rabu-m365-sandbox` — New Level 2 Connectivity
- `level2/level.hcl` and `level2/connectivity/area.hcl` scaffolding
- `az-alz-connectivity-virtual-wan-main-location/` — vWAN Terragrunt unit + JSON artefact library (virtualHubs, vpnConnections, vpnGateways, vpnSites)
- `az-connectivity-management/terragrunt.hcl` — connectivity management unit

### Both tenants (`dark-contoso-lab`, `rabu-m365-sandbox`)
- `entraid-policies/terragrunt.hcl` → `terragrunt.hcl.disabled` (module disabled)
- `env.hcl` HCL alignment formatting fixes

### Docs
- `copilot-instructions.md` updated to reflect the new path extraction regex